### PR TITLE
Update pip dependencies to match KPI 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,14 +26,14 @@ setuptools.setup(
     },
     install_requires=[
         'oyaml==0.9',
-        'jsonschema==3.2.0',
+        'jsonschema==4.4.0',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
 )
 
 # pytest --cov=a1d05eba1 tests/ --cov-report=html


### PR DESCRIPTION
All dependencies of KPI have been updated to their latest version with Django 3.2.
It's using json-schema=4.4.0 whereas `a1d04eba` was using `3.x` . 
Because of that, pip-sync was complaining about version conflicts when building.